### PR TITLE
Added license field, bug URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,9 +13,11 @@
     "node-red",
     "Max Cube"
   ],
-  "author": {
-    "name": "Ives De Bruycker"
-  },
+  "author": "Ives De Bruycker",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/ivesdebruycker/node-red-contrib-maxcube/issues"
+  }
   "node-red": {
     "nodes": {
       "maxcube": "maxcube.js"


### PR DESCRIPTION
To avoid warning from npm: npm WARN node-red-contrib-maxcube@0.0.5 No license field.