### PR TITLE
Fix npm warning by adding license field

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "license": "ISC",
   "bugs": {
     "url": "https://github.com/ivesdebruycker/node-red-contrib-maxcube/issues"
-  }
+  },
   "node-red": {
     "nodes": {
       "maxcube": "maxcube.js"

--- a/package.json
+++ b/package.json
@@ -13,9 +13,11 @@
     "node-red",
     "Max Cube"
   ],
-  "author": {
-    "name": "Ives De Bruycker"
-  },
+  "author": "Ives De Bruycker",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/ivesdebruycker/node-red-contrib-maxcube/issues"
+  }
   "node-red": {
     "nodes": {
       "maxcube": "maxcube.js"


### PR DESCRIPTION
This PR adds a license field and the URL for bugs. Fixes npm warning 

`npm WARN node-red-contrib-maxcube@0.0.5 No license field.`

that happens ATM