### PR TITLE
fix endless reconnect loop

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@ node-red-contrib-maxcube2 is a fork of https://github.com/ivesdebruycker/node-re
 
 ### Changes from node-red-contrib-maxcube
 - Settings to temporary disable maxcube connection (the cube can handle only one TCP connection at a time, since maxcube/maxcube2 use a permanent connection if you want to temporary use another client you have to stop node-red...now you can disable in node settings)
-- I'm planning to expose some additional data provided by maxcube2 (device configurations, min/max/eco/comfort temperatures etc.)
+- Node to query devices configurations
+- I'm planning add some additional features provided by maxcube2 (schedule, etc)
 
 The old API didn't change currently so it's a drop-in replacement.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,16 @@
 # node-red-contrib-maxcube
 A collection of node-red nodes to control the eQ-3 Max! Cube
 
+## Introduction
+### History
+node-red-contrib-maxcube2 is a fork of https://github.com/ivesdebruycker/node-red-contrib-maxcube using https://github.com/normen/maxcube2.
+
+### Changes from node-red-contrib-maxcube
+- Settings to temporary disable maxcube connection (the cube can handle only one TCP connection at a time, since maxcube/maxcube2 use a permanent connection if you want to temporary use another client you have to stop node-red...now you can disable in node settings)
+- I'm planning to expose some additional data provided by maxcube2 (device configurations, min/max/eco/comfort temperatures etc.)
+
+The old API didn't change currently so it's a drop-in replacement.
+
 ## Installation
 ```
 cd $HOME/.node-red
@@ -31,7 +41,9 @@ Whenever an input message is received, device states are updated from the Max! C
   "battery_low": false,
   "valve": 0,
   "setpoint": 5,
-  "temp": 15.4
+  "temp": 15.4,
+  "device_name": "Termosifone"
+  "room_name": "Bagno"
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ node-red-contrib-maxcube2 is a fork of https://github.com/ivesdebruycker/node-re
 ### Changes from node-red-contrib-maxcube
 - Settings to temporary disable maxcube connection (the cube can handle only one TCP connection at a time, since maxcube/maxcube2 use a permanent connection if you want to temporary use another client you have to stop node-red...now you can disable in node settings)
 - Node to query devices configurations
+- Set mode to all devices with a single payload ({"mode" : "AUTO"} without rf_address)
 - I'm planning add some additional features provided by maxcube2 (schedule, etc)
 
 The old API didn't change currently so it's a drop-in replacement.
@@ -53,10 +54,32 @@ A node to set the temperature and/or the mode of a device.
 Valid modes are "AUTO", "MANUAL" and "BOOST".
 
 Accepts messages with payload of type object with following structure:
+
+MANUAL on specific device
 ```
 {
   "rf_address": "0abc12",
   "degrees": 20,
   "mode":"MANUAL"
+}
+```
+MANUAL on all devices
+```
+{
+  "degrees": 20,
+  "mode":"MANUAL"
+}
+```
+AUTO on all devices
+```
+{
+  "mode":"AUTO"
+}
+```
+VACATION on all devices until specific date (ISO 8601)
+```
+{
+  "mode":"VACATION",
+  "untilDate" : "2019-06-20T10:00:00Z"
 }
 ```

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ node-red-contrib-maxcube2 is a fork of https://github.com/ivesdebruycker/node-re
 - Settings to temporary disable maxcube connection (the cube can handle only one TCP connection at a time, since maxcube/maxcube2 use a permanent connection if you want to temporary use another client you have to stop node-red...now you can disable in node settings)
 - Node to query devices configurations
 - Set mode to all devices with a single payload ({"mode" : "AUTO"} without rf_address)
+- Output devices data as single message or separeted messages
 - I'm planning add some additional features like schedule settings
 
 The old API didn't change currently so it's a drop-in replacement.
@@ -30,29 +31,96 @@ A node to query the eQ-3 Max! Cube for device states.
 Whenever an input message is received, device states are updated from the Max! Cube, and sent as separate messages (one for each device) with following structure:
 ```
 {
-  "rf_address": "0abc12",
-  "initialized": true,
-  "fromCmd": false,
-  "error": false,
-  "valid": true,
-  "mode": "MANUAL",
-  "dst_active": true,
-  "gateway_known": true,
-  "panel_locked": false,
-  "link_error": false,
-  "battery_low": false,
-  "valve": 0,
-  "setpoint": 5,
-  "temp": 15.4,
-  "device_name": "Termosifone"
-  "room_name": "Bagno"
+    "rf_address": "1709d7",
+    "initialized": true,
+    "fromCmd": false,
+    "error": false,
+    "valid": true,
+    "mode": "AUTO",
+    "dst_active": true,
+    "gateway_known": true,
+    "panel_locked": false,
+    "link_error": false,
+    "battery_low": false,
+    "valve": 0,
+    "setpoint": 17,
+    "temp": 0,
+    "device_type": 1,
+    "device_name": "Termosifone Sala TV",
+    "room_name": "Piano terra",
+    "room_id": 1
+}
+```
+or as a single message with the following structure:
+```
+{
+    "1709d7": {
+        "rf_address": "1709d7",
+        "initialized": true,
+        "fromCmd": false,
+        "error": false,
+        "valid": true,
+        "mode": "AUTO",
+        "dst_active": true,
+        "gateway_known": true,
+        "panel_locked": false,
+        "link_error": false,
+        "battery_low": false,
+        "valve": 0,
+        "setpoint": 17,
+        "temp": 0,
+        "device_type": 1,
+        "device_name": "Termosifone Sala TV",
+        "room_name": "Piano terra",
+        "room_id": 1
+    },
+    "18eb18": {
+        "rf_address": "18eb18",
+        "initialized": true,
+        "fromCmd": false,
+        "error": false,
+        "valid": true,
+        "mode": "AUTO",
+        "dst_active": true,
+        "gateway_known": true,
+        "panel_locked": false,
+        "link_error": false,
+        "battery_low": false,
+        "valve": 4,
+        "setpoint": 17
+        "temp": 27.2,
+        "device_type": 3,
+        "device_name": "Termostato a parete",
+        "room_name": "Piano terra",
+        "room_id": 1
+    }
+    "0a1d0e": {
+        "rf_address": "0a1d0e",
+        "open": false,
+        "device_type": 5,
+        "device_name": "Pulsante Eco"
+    }
 }
 ```
 
 ### maxcube configuration (input)
 A node to query the eQ-3 Max! Cube for device states.
 
-Whenever an input message is received, device configuration are updated from the Max! Cube, and sent  and send it as single message with following structure:
+Whenever an input message is received, device configuration are updated from the Max! Cube, and sent as separate messages (one for each device) with following structure:
+```
+{
+   "rf_address":"18b444",
+   "device_type":1,
+   "serial_number":"OEQ1131666",
+   "comfort_temp":21.5,
+   "eco_temp":16.5,
+   "max_setpoint_temp":30,
+   "min_setpoint_temp":4.5,
+   "temp_offset":0,
+   "max_valve":100
+}
+```
+or as a single message with the following structure:
 ```
 {
    "18b444":{
@@ -79,7 +147,6 @@ Whenever an input message is received, device configuration are updated from the
    }
 }
 ```
-
 
 ### maxcube (output)of a device
 A node to set the temperature and/or the mode of a device.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# node-red-contrib-maxcube
+# node-red-contrib-maxcube2
 A collection of node-red nodes to control the eQ-3 Max! Cube
 
 ## Introduction
@@ -9,14 +9,14 @@ node-red-contrib-maxcube2 is a fork of https://github.com/ivesdebruycker/node-re
 - Settings to temporary disable maxcube connection (the cube can handle only one TCP connection at a time, since maxcube/maxcube2 use a permanent connection if you want to temporary use another client you have to stop node-red...now you can disable in node settings)
 - Node to query devices configurations
 - Set mode to all devices with a single payload ({"mode" : "AUTO"} without rf_address)
-- I'm planning add some additional features provided by maxcube2 (schedule, etc)
+- I'm planning add some additional features like schedule settings
 
 The old API didn't change currently so it's a drop-in replacement.
 
 ## Installation
 ```
 cd $HOME/.node-red
-npm install node-red-contrib-maxcube
+npm install node-red-contrib-maxcube2
 ```
 Restart Node-RED.
 
@@ -49,9 +49,41 @@ Whenever an input message is received, device states are updated from the Max! C
 }
 ```
 
+### maxcube configuration (input)
+A node to query the eQ-3 Max! Cube for device states.
+
+Whenever an input message is received, device configuration are updated from the Max! Cube, and sent  and send it as single message with following structure:
+```
+{
+   "18b444":{
+      "rf_address":"18b444",
+      "device_type":1,
+      "serial_number":"OEQ1131666",
+      "comfort_temp":21.5,
+      "eco_temp":16.5,
+      "max_setpoint_temp":30,
+      "min_setpoint_temp":4.5,
+      "temp_offset":0,
+      "max_valve":100
+   },
+   "1709a1":{
+      "rf_address":"1709a1",
+      "device_type":1,
+      "serial_number":"NKF0004984",
+      "comfort_temp":21.5,
+      "eco_temp":16.5,
+      "max_setpoint_temp":30,
+      "min_setpoint_temp":4.5,
+      "temp_offset":0,
+      "max_valve":100
+   }
+}
+```
+
+
 ### maxcube (output)of a device
 A node to set the temperature and/or the mode of a device.
-Valid modes are "AUTO", "MANUAL" and "BOOST".
+Valid modes are "AUTO", "MANUAL", "BOOST" and "VACATION".
 
 Accepts messages with payload of type object with following structure:
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ node-red-contrib-maxcube2 is a fork of https://github.com/ivesdebruycker/node-re
 - Node to query devices configurations
 - Set mode to all devices with a single payload ({"mode" : "AUTO"} without rf_address)
 - Output devices data as single message or separeted messages
+- Send a reset command to devices not reacting to other commands
 - I'm planning add some additional features like schedule settings
 
 The old API didn't change currently so it's a drop-in replacement.
@@ -149,7 +150,7 @@ or as a single message with the following structure:
 ```
 
 ### maxcube (output)of a device
-A node to set the temperature and/or the mode of a device.
+A node to set the temperature and/or the mode of a device and/or reset a device.
 Valid modes are "AUTO", "MANUAL", "BOOST" and "VACATION".
 
 Accepts messages with payload of type object with following structure:
@@ -181,4 +182,19 @@ VACATION on all devices until specific date (ISO 8601)
   "mode":"VACATION",
   "untilDate" : "2019-06-20T10:00:00Z"
 }
+```
+Reset a device
+```
+{
+  "rf_address": "0abc12",
+  "reset": true
+}
+```
+Reset all devices
+```
+{
+  "reset": true
+}
+```
+The reset field can also be added to any of the above commands to issue a reset command before sending the temperature update.
 ```

--- a/maxcube.html
+++ b/maxcube.html
@@ -39,7 +39,8 @@
     category: 'input',
     color: '#F3B567',
     defaults: {
-      server: { value: '', type: 'maxcube-server' }
+      server: { value: '', type: 'maxcube-server' },
+      singleMessage : { value: false, required: false }
     },
     inputs: 1,
     outputs: 1,
@@ -56,26 +57,92 @@
         <label for="node-input-server"><i class="icon-tag"></i> Server</label>
         <input type="text" id="node-input-server">
     </div>
+    <div class="form-row">
+      <label for="node-input-singleMessage"><i class="icon-file"></i></label>
+      <input type="checkbox" id="node-input-singleMessage" style="display:inline-block; width:15px; vertical-align:baseline;"> Output to single message
+    </div>
+    <div class="form-tips">
+      <span<b>Note:</b> If "Output to single message" is checked the node will send only one message containing all devices requested data</span>
+    </div>
 </script>
 
 <script type="text/x-red" data-help-name="maxcube out">
     <p>A node to query the eQ-3 Max! Cube</p>
     <p>Whenever an input is received, device status is updated from the Maxcube, and sent as separate messages (one for each device) of form:
-      <pre>{ "rf_address": "0abc12",
-  "initialized": true,
-  "fromCmd": false,
-  "error": false,
-  "valid": true,
-  "mode": "MANUAL",
-  "dst_active": true,
-  "gateway_known": true,
-  "panel_locked": false,
-  "link_error": false,
-  "battery_low": false,
-  "valve": 0,
-  "setpoint": 5,
-  "temp": 15.4
-}</pre></p>
+      <pre>{
+    "rf_address": "1709d7",
+    "initialized": true,
+    "fromCmd": false,
+    "error": false,
+    "valid": true,
+    "mode": "AUTO",
+    "dst_active": true,
+    "gateway_known": true,
+    "panel_locked": false,
+    "link_error": false,
+    "battery_low": false,
+    "valve": 0,
+    "setpoint": 17,
+    "temp": 0,
+    "device_type": 1,
+    "device_name": "Termosifone Sala TV",
+    "room_name": "Piano terra",
+    "room_id": 1
+}</pre>
+</p>
+
+<p>or sent as single message of form:
+  <pre>
+  {
+      "1709d7": {
+          "rf_address": "1709d7",
+          "initialized": true,
+          "fromCmd": false,
+          "error": false,
+          "valid": true,
+          "mode": "AUTO",
+          "dst_active": true,
+          "gateway_known": true,
+          "panel_locked": false,
+          "link_error": false,
+          "battery_low": false,
+          "valve": 0,
+          "setpoint": 17,
+          "temp": 0,
+          "device_type": 1,
+          "device_name": "Termosifone Sala TV",
+          "room_name": "Piano terra",
+          "room_id": 1
+      },
+      "18eb18": {
+          "rf_address": "18eb18",
+          "initialized": true,
+          "fromCmd": false,
+          "error": false,
+          "valid": true,
+          "mode": "AUTO",
+          "dst_active": true,
+          "gateway_known": true,
+          "panel_locked": false,
+          "link_error": false,
+          "battery_low": false,
+          "valve": 4,
+          "setpoint": 17
+          "temp": 27.2,
+          "device_type": 3,
+          "device_name": "Termostato a parete",
+          "room_name": "Piano terra",
+          "room_id": 1
+      }
+      "0a1d0e": {
+          "rf_address": "0a1d0e",
+          "open": false,
+          "device_type": 5,
+          "device_name": "Pulsante Eco"
+      }
+  }
+  </pre></p>
+
 </script>
 
 <script type="text/javascript">
@@ -83,7 +150,8 @@
     category: 'input',
     color: '#F3B567',
     defaults: {
-      server: { value: '', type: 'maxcube-server' }
+      server: { value: '', type: 'maxcube-server' },
+      singleMessage : { value: false, required: false }
     },
     inputs: 1,
     outputs: 1,
@@ -100,11 +168,34 @@
         <label for="node-input-server"><i class="icon-tag"></i> Server</label>
         <input type="text" id="node-input-server">
     </div>
+    <div class="form-row">
+      <label for="node-input-singleMessage"><i class="icon-file"></i></label>
+      <input type="checkbox" id="node-input-singleMessage" style="display:inline-block; width:15px; vertical-align:baseline;"> Output to single message
+    </div>
+    <div class="form-tips">
+      <span<b>Note:</b> If "Output to single message" is checked the node will send only one message containing all devices requested data</span>
+    </div>
 </script>
 
 <script type="text/x-red" data-help-name="maxcube device config">
     <p>A node to query the eQ-3 Max! Cube devices configuration</p>
-    <p>Whenever an input is received, devices configuration is updated from the Maxcube, and send it as single message of form:
+    <p>Whenever an input is received, devices configuration is updated from the Maxcube, and sent as separate messages (one for each device) of form:
+      <pre>
+      {
+         "rf_address":"18b444",
+         "device_type":1,
+         "serial_number":"OEQ1131666",
+         "comfort_temp":21.5,
+         "eco_temp":16.5,
+         "max_setpoint_temp":30,
+         "min_setpoint_temp":4.5,
+         "temp_offset":0,
+         "max_valve":100
+      }
+      </pre>
+    </p>
+    <p>or sent as single message of form:
+      <pre>
       <pre>
       {
          "18b444":{
@@ -160,7 +251,7 @@
         <input type="text" id="node-config-input-port" placeholder="port">
     </div>
     <div class="form-row">
-        <label for="node-config-input-disabled"><i class="icon-lan-disconnect"></i> Disabled</label>
+        <label for="node-config-input-disabled"><i class="icon-pause"></i> Disabled</label>
         <input type="checkbox" id="node-config-input-disabled" >
     </div>
 </script>

--- a/maxcube.html
+++ b/maxcube.html
@@ -6,7 +6,7 @@
       server: { value: '', type: 'maxcube-server' }
     },
     inputs: 1,
-    outputs: 0,
+    outputs: 1,
     icon: 'bridge.png',
     label: function() {
       return this.name || 'Maxcube';

--- a/maxcube.html
+++ b/maxcube.html
@@ -84,10 +84,11 @@
     category: 'config',
     defaults: {
       host: { value:'', required: true },
-      port: { value: 62910, required: true, validate: RED.validators.number() }
+      port: { value: 62910, required: true, validate: RED.validators.number() },
+      disabled: { value: true, required: false }
     },
     label: function() {
-      return this.host + ':' + this.port;
+        return this.host + ':' + this.port ;
     }
   });
 </script>
@@ -100,5 +101,9 @@
     <div class="form-row">
         <label for="node-config-input-port"><i class="icon-tag"></i> Port</label>
         <input type="text" id="node-config-input-port" placeholder="port">
+    </div>
+    <div class="form-row">
+        <label for="node-config-input-disabled"><i class="icon-lan-disconnect"></i> Disabled</label>
+        <input type="checkbox" id="node-config-input-disabled" >
     </div>
 </script>

--- a/maxcube.html
+++ b/maxcube.html
@@ -24,7 +24,7 @@
 
 <script type="text/x-red" data-help-name="maxcube in">
     <p>A node to control the eQ-3 Max! Cube</p>
-    <p>Accepts messages with payload of type object with following structure: 
+    <p>Accepts messages with payload of type object with following structure:
       <pre>{
   "rf_address": "0abc12",
   "degrees": 20,
@@ -77,6 +77,63 @@
   "temp": 15.4
 }</pre></p>
 </script>
+
+<script type="text/javascript">
+  RED.nodes.registerType('maxcube device config',{
+    category: 'input',
+    color: '#F3B567',
+    defaults: {
+      server: { value: '', type: 'maxcube-server' }
+    },
+    inputs: 1,
+    outputs: 1,
+    icon: 'bridge.png',
+    label: function() {
+      return this.name || 'Maxcube configuration';
+    },
+    align: 'left'
+  });
+</script>
+
+<script type="text/x-red" data-template-name="maxcube device config">
+    <div class="form-row">
+        <label for="node-input-server"><i class="icon-tag"></i> Server</label>
+        <input type="text" id="node-input-server">
+    </div>
+</script>
+
+<script type="text/x-red" data-help-name="maxcube device config">
+    <p>A node to query the eQ-3 Max! Cube devices configuration</p>
+    <p>Whenever an input is received, devices configuration is updated from the Maxcube, and send it as single message of form:
+      <pre>
+      {
+         "18b444":{
+            "rf_address":"18b444",
+            "device_type":1,
+            "serial_number":"OEQ1131666",
+            "comfort_temp":21.5,
+            "eco_temp":16.5,
+            "max_setpoint_temp":30,
+            "min_setpoint_temp":4.5,
+            "temp_offset":0,
+            "max_valve":100
+         },
+         "1709a1":{
+            "rf_address":"1709a1",
+            "device_type":1,
+            "serial_number":"NKF0004984",
+            "comfort_temp":21.5,
+            "eco_temp":16.5,
+            "max_setpoint_temp":30,
+            "min_setpoint_temp":4.5,
+            "temp_offset":0,
+            "max_valve":100
+         }
+      }
+      </pre>
+    </p>
+</script>
+
 
 
 <script type="text/javascript">

--- a/maxcube.html
+++ b/maxcube.html
@@ -28,7 +28,8 @@
       <pre>{
   "rf_address": "0abc12",
   "degrees": 20,
-  "mode": "MANUAL"
+  "mode": "MANUAL",
+  "reset": false
 }</pre>
     </p>
 </script>

--- a/maxcube.js
+++ b/maxcube.js
@@ -1,4 +1,4 @@
-var MaxCube = require('maxcube');
+var MaxCube = require('maxcube2');
 
 module.exports = function(RED) {
   function MaxcubeNodeIn(config) {

--- a/maxcube.js
+++ b/maxcube.js
@@ -98,6 +98,7 @@ module.exports = function(RED) {
           } else {
             node.log('Error setting temperature (' + data+ ')');
           }
+          node.status({fill:"green",shape:"dot",text: "last msg: "+JSON.stringify(data)});
           sendCommStatus(node, success, data);
         }).catch(function(e) {
           node.warn(e);
@@ -144,7 +145,7 @@ module.exports = function(RED) {
     node.on('input', function(msg) {
       if(checkInputDisabled(node)){
         return;
-      };
+      }
 
       var additionalData = function(deviceStatus, maxCube){
         var deviceInfo = maxCube.getDeviceInfo(deviceStatus.rf_address);
@@ -157,7 +158,7 @@ module.exports = function(RED) {
             }
           }
         }
-      }
+      };
 
       var maxCube = node.serverConfig.maxCube;
       var duty_cycle = maxCube.getCommStatus();
@@ -183,6 +184,7 @@ module.exports = function(RED) {
              return { rf_address: deviceStatus.rf_address, payload: deviceStatus };
            })]);
          }
+         node.status({fill:"green",shape:"dot",text: "last call: "+new Date().toTimeString()});
       });
     });
   }
@@ -223,6 +225,7 @@ module.exports = function(RED) {
              return { rf_address: deviceStatus.rf_address, payload: conf };
            })]);
          }
+         node.status({fill:"green",shape:"dot",text: "last call: "+new Date().toTimeString()});
       });
     });
   }

--- a/maxcube.js
+++ b/maxcube.js
@@ -261,8 +261,13 @@ module.exports = function(RED) {
       if(node.maxCube){
         node.log("Preparing new Maxcube events callback");
         node.maxCube.on('closed', function () {
-          node.log("Maxcube connection closed...");
           connected = false;
+          if(node.maxCube != null) {
+            node.log("Maxcube connection closed unexpectedly... will try to reconnect.");
+            node.maxcubeConnect();
+          }
+          else
+            node.log("Maxcube connection closed...");
         });
         node.maxCube.on('error', function (e) {
           node.log("Error connecting to the cube.");
@@ -281,7 +286,9 @@ module.exports = function(RED) {
 
     node.on("close", function() {
       if(node.maxCube){
-        node.maxCube.close();
+        var maxCube = node.maxCube;
+        node.maxCube = null;
+        maxCube.close();
       }
     });
 

--- a/maxcube.js
+++ b/maxcube.js
@@ -102,6 +102,36 @@ module.exports = function(RED) {
   }
   RED.nodes.registerType("maxcube out", MaxcubeNodeOut);
 
+
+  function MaxcubeDeviceConfigNodeOut(config) {
+    var node = this;
+    if(!initNode(node, config)){
+      return;
+    }
+
+    node.on('input', function(msg) {
+      if(checkInputDisabled(node)){
+        return;
+      };
+
+      var maxCube = node.serverConfig.maxCube;
+      node.log(JSON.stringify(maxCube.getCommStatus()));
+      maxCube.getDeviceStatus().then(function (devices) {
+
+        // add every single device to the payload
+        var devicesConfig = {};
+        for (var i = 0; i < devices.length; i++) {
+          var deviceStatus = devices[i];
+          var conf = maxCube.getDeviceConfiguration(deviceStatus.rf_address);
+          devicesConfig[deviceStatus.rf_address] = conf;
+        }
+        node.send({payload: devicesConfig});
+      });
+    });
+  }
+  RED.nodes.registerType("maxcube device config", MaxcubeDeviceConfigNodeOut);
+
+
   function MaxcubeServerNode(config) {
     var node = this;
     RED.nodes.createNode(this, config);

--- a/maxcube.js
+++ b/maxcube.js
@@ -49,6 +49,13 @@ module.exports = function(RED) {
     return false;
   }
 
+  function validateMsg(msg){
+    //maxcube.js won't accept mode if lowercase
+    if(msg.payload.mode){
+      msg.payload.mode = msg.payload.mode.toUpperCase();
+    }
+  }
+
   function MaxcubeNodeIn(config) {
     var node = this;
     if(!initNode(node, config)){
@@ -60,14 +67,17 @@ module.exports = function(RED) {
         return;
       };
 
+      validateMsg(msg);
+
       var maxCube = node.serverConfig.maxCube;
 
       var setTemp = function(rf_address, degrees, mode, untilDate){
         maxCube.setTemperature(rf_address, degrees, mode, untilDate).then(function (success) {
+          var data = [rf_address, degrees, mode, untilDate].filter(function (val) {return val;}).join(', ')
           if (success) {
-            node.log('Temperature set (' + [rf_address, degrees, mode, untilDate].filter(function (val) {return val;}).join(', ') + ')');
+            node.log('Temperature set (' + data+ ')');
           } else {
-            node.log('Error setting temperature');
+            node.log('Error setting temperature (' + data+ ')');
           }
         }).catch(function(e) {
           node.warn(e);

--- a/maxcube.js
+++ b/maxcube.js
@@ -110,7 +110,6 @@ module.exports = function(RED) {
 
       var resetDevice = function( rf_address ){
         // Timeout after 30 seconds
-        node.log( 'Calling resetError for ' + rf_address );
         return maxCube.resetError( rf_address, 30000 ).then( function (success) {
           node.status( { fill: 'green', shape: 'dot', text: 'last msg: reset ' + JSON.stringify(rf_address) } );
           sendCommStatus(node, success, rf_address);
@@ -118,7 +117,7 @@ module.exports = function(RED) {
             node.log( 'Device reset: ' + rf_address );
             return true;
           } else {
-            node.log( 'Reset command for device ' + rf_address + ' discarded by cube. Maybe duty cycle exceeded.' );
+            node.warn( 'Reset command for device ' + rf_address + ' discarded by cube. Maybe duty cycle exceeded.' );
             throw new Error( 'Reset command discarded.' );
           }
         } ).catch( function( e ) {
@@ -147,16 +146,13 @@ module.exports = function(RED) {
         }
         
         if( payload.reset ){
-          node.log( 'Calling resetDevice for ' + rf_address );
           return resetDevice( rf_address ).then( function( success ) {
-            node.log( 'Calling setTempFunc for ' + rf_address );
             return setTempFunc();
           } ).catch( function( err ) {
             // do nothing, everything has been done already
             // but still catch the error, because uncaught errors are bad
           } );
         } else {
-          node.log( 'Calling setTempFunc for ' + rf_address );
           return setTempFunc();
         }
       };

--- a/maxcube.js
+++ b/maxcube.js
@@ -88,7 +88,8 @@ module.exports = function(RED) {
 
 
       var setTemp = function(rf_address, degrees, mode, untilDate){
-        maxCube.setTemperature(rf_address, degrees, mode, untilDate).then(function (success) {
+        // Give the cube 30 seconds to anwer
+        maxCube.setTemperature(rf_address, degrees, mode, untilDate, 30000).then(function (success) {
           var data = [rf_address, degrees, mode, untilDate].filter(function (val) {return val;}).join(', ');
           if (success) {
             node.log('Temperature set (' + data+ ')');
@@ -109,7 +110,8 @@ module.exports = function(RED) {
         setTemp(msg.payload.rf_address, msg.payload.degrees, msg.payload.mode, msg.payload.untilDate);
       }else{
         //all devices: query getDeviceStatus, then update all!
-        maxCube.getDeviceStatus().then(function (devices) {
+        // Give the cube 30 seconds to answer
+        maxCube.getDeviceStatus( undefined, 30000 ).then(function (devices) {
           for (var i = 0; i < devices.length; i++) {
             var deviceStatus = devices[i];
             //ignoring eco buttons/window switch/etc
@@ -160,7 +162,8 @@ module.exports = function(RED) {
       var maxCube = node.serverConfig.maxCube;
       var duty_cycle = maxCube.getCommStatus();
       node.log(JSON.stringify(duty_cycle));
-      maxCube.getDeviceStatus().then(function (devices) {
+      // Give the cube 30 seconds to answer
+      maxCube.getDeviceStatus( undefined, 30000).then(function (devices) {
 
         if(node.singleMessage){
           // send devices statuses as single message
@@ -202,7 +205,8 @@ module.exports = function(RED) {
       var maxCube = node.serverConfig.maxCube;
       var duty_cycle = maxCube.getCommStatus();
       node.log(JSON.stringify(duty_cycle));
-      maxCube.getDeviceStatus().then(function (devices) {
+      // Give the cube 30 seconds to answer
+      maxCube.getDeviceStatus( undefined, 30000 ).then(function (devices) {
 
         if(node.singleMessage){
           // send devices statuses as single message

--- a/maxcube.js
+++ b/maxcube.js
@@ -95,7 +95,7 @@ module.exports = function(RED) {
             if(deviceInfo.device_type == '1' || deviceInfo.device_type == '2' || deviceInfo.device_type == '3'){
               setTemp(deviceStatus.rf_address, msg.payload.degrees, msg.payload.mode, msg.payload.untilDate);
             }else{
-              node.warn("Ignoring device "+deviceStatus.rf_address + "(device_type "+deviceInfo.device_type+")");
+              node.log("Ignoring device "+deviceStatus.rf_address + "(device_type "+deviceInfo.device_type+")");
             }
           }
         });
@@ -118,10 +118,13 @@ module.exports = function(RED) {
       var additionalData = function(deviceStatus, maxCube){
         var deviceInfo = maxCube.getDeviceInfo(deviceStatus.rf_address);
         if(deviceInfo){
-          deviceStatus.device_type = deviceInfo.device_type;
-          deviceStatus.device_name = deviceInfo.device_name;
-          deviceStatus.room_name = deviceInfo.room_name;
-          deviceStatus.room_id = deviceInfo.room_id;
+          var whitelist = ['device_type', 'device_name', 'room_name', 'room_id'];
+          for (var i = 0; i < whitelist.length; i++) {
+            var key = whitelist[i];
+            if(deviceInfo[key]){
+                deviceStatus[key] = deviceInfo[key];
+            }
+          }
         }
       }
 

--- a/maxcube.js
+++ b/maxcube.js
@@ -2,45 +2,65 @@ var MaxCube = require('maxcube');
 
 module.exports = function(RED) {
 
-  function statusEvents(node){
-    if(node.maxCube){
-      node.maxCube.on('closed', function () {
+  //missing configurations
+  function initNode(node, config){
+    //create node
+    RED.nodes.createNode(node, config);
+    //check configurations
+    node.serverConfig = RED.nodes.getNode(config.server);
+    if (!node.serverConfig) {
+      return false;
+    }
+
+    //handle status icons
+    var maxCube = node.serverConfig.maxCube;
+    if(maxCube){
+      maxCube.on('closed', function () {
         node.status({fill:"red",shape:"ring",text:"disconnected"});
       });
 
-      node.maxCube.on('connected', function () {
+      maxCube.on('connected', function () {
         node.status({fill:"green",shape:"dot",text:"connected"});
       });
     }
+
+    return true;
+  }
+
+  function checkInputDisabled(node){
+    var serverConfig = node.serverConfig;
+    //temporary disabled by settings
+    if(serverConfig.disabled){
+        node.status({fill:"yellow",shape:"dot",text:"disabled"});
+        node.warn("maxcube "+serverConfig.host+" disabled");
+        //close existing
+        if(serverConfig.maxCube){
+          node.warn("closing exising connection: "+serverConfig.host);
+          serverConfig.maxCube.close();
+        }
+        return true;
+    }
+
+    if(!serverConfig.maxCube){
+      node.warn("maxCube item is not ready");
+      node.status({fill:"red",shape:"ring",text:"error"});
+    }
+    return false;
   }
 
   function MaxcubeNodeIn(config) {
     var node = this;
-    RED.nodes.createNode(this, config);
-
-    this.serverConfig = RED.nodes.getNode(config.server);
-
-    if (!this.serverConfig) {
+    if(!initNode(node, config)){
       return;
     }
 
-    node.maxCube = this.serverConfig.maxCube;
-    statusEvents(node);
-
     node.on('input', function(msg) {
-      //temporary disabled by settings
-      if(this.serverConfig.disabled ){
-          node.status({fill:"yellow",shape:"dot",text:"disabled"});
-          node.warn("maxcube "+this.serverConfig.host+" disabled");
-          //close existing
-          if(node.maxCube){
-            node.warn("closing exising connection: "+this.serverConfig.host);
-            node.maxCube.close();
-          }
-          return;
-      }
+      if(checkInputDisabled(node)){
+        return;
+      };
 
-      node.maxCube.setTemperature(msg.payload.rf_address, msg.payload.degrees, msg.payload.mode, msg.payload.untilDate).then(function (success) {
+      var maxCube = node.serverConfig.maxCube;
+      maxCube.setTemperature(msg.payload.rf_address, msg.payload.degrees, msg.payload.mode, msg.payload.untilDate).then(function (success) {
         if (success) {
           node.log('Temperature set (' + [msg.payload.rf_address, msg.payload.degrees, msg.payload.mode, msg.payload.untilDate].filter(function (val) {return val;}).join(', ') + ')');
         } else {
@@ -55,36 +75,22 @@ module.exports = function(RED) {
 
   function MaxcubeNodeOut(config) {
     var node = this;
-    RED.nodes.createNode(this, config);
-
-    this.serverConfig = RED.nodes.getNode(config.server);
-
-    if (!this.serverConfig) {
+    if(!initNode(node, config)){
       return;
     }
 
-    node.maxCube = this.serverConfig.maxCube;
-    statusEvents(node);
-
     node.on('input', function(msg) {
-      //temporary disabled by settings
-      if(this.serverConfig.disabled ){
-          node.status({fill:"yellow",shape:"dot",text:"disabled"});
-          node.warn("maxcube "+this.serverConfig.host+" disabled");
-          //close existing
-          if(node.maxCube){
-            node.warn("closing exising connection: "+this.serverConfig.host);
-            node.maxCube.close();
-          }
-          return;
-      }
+      if(checkInputDisabled(node)){
+        return;
+      };
 
-      node.log(JSON.stringify(node.maxCube.getCommStatus()));
-      node.maxCube.getDeviceStatus().then(function (payload) {
+      var maxCube = node.serverConfig.maxCube;
+      node.log(JSON.stringify(maxCube.getCommStatus()));
+      maxCube.getDeviceStatus().then(function (payload) {
         // send devices statuses as separate messages
         node.send([payload.map(function function_name(deviceStatus) {
             // add device name, room name, to status object
-            var deviceInfo = node.maxCube.getDeviceInfo(deviceStatus.rf_address);
+            var deviceInfo = maxCube.getDeviceInfo(deviceStatus.rf_address);
             if(deviceInfo!==undefined){
               deviceStatus.device_name = deviceInfo.device_name;
               deviceStatus.room_name = deviceInfo.room_name;

--- a/maxcube.js
+++ b/maxcube.js
@@ -23,6 +23,11 @@ module.exports = function(RED) {
       maxCube.on('connected', function () {
         node.status({fill:"green",shape:"dot",text:"connected"});
       });
+
+      maxCube.on('error', function (err) {
+        node.log(err);
+        node.status({fill:"red",shape:"dot",text:"Error: "+err});
+      });
     }
 
     return true;

--- a/maxcube.js
+++ b/maxcube.js
@@ -261,8 +261,8 @@ module.exports = function(RED) {
           node.emit('closed');
           connected = false;
           if(node.maxCube != null) {
-            node.log("Maxcube connection closed unexpectedly... will try to reconnect.");
-            node.maxcubeConnect();
+            node.log("Maxcube connection closed unexpectedly... will try to reconnect in one second.");
+            setTimeout( node.maxcubeConnect, 1000 );
           }
           else
             node.log("Maxcube connection closed...");
@@ -273,8 +273,8 @@ module.exports = function(RED) {
           node.log(JSON.stringify(e));
           connected = false;
           //force node to init connection if not available
-          node.log("Maxcube was disconnected... will try to reconnect.");
-          node.maxcubeConnect();
+          node.log("Maxcube was disconnected... will try to reconnect in one second.");
+          setTimeout( node.maxcubeConnect, 1000 );
         });
         node.maxCube.on('connected', function () {
           node.emit('connected');

--- a/maxcube.js
+++ b/maxcube.js
@@ -241,6 +241,7 @@ module.exports = function(RED) {
     node.maxcubeConnect = function(){
 
       if(node.maxCube){
+         node.maxCube.removeAllListeners('closed');
          node.maxCube.close();
          node.maxCube = undefined;
       }

--- a/maxcube.js
+++ b/maxcube.js
@@ -27,21 +27,18 @@ module.exports = function(RED) {
     }
 
     //handle status icons
-    var maxCube = node.serverConfig.maxCube;
-    if(maxCube){
-      maxCube.on('closed', function () {
-        node.status({fill:"red",shape:"ring",text:"disconnected"});
-      });
+    node.serverConfig.on('closed', function () {
+      node.status({fill:"red",shape:"ring",text:"disconnected"});
+    });
 
-      maxCube.on('connected', function () {
-        node.status({fill:"green",shape:"dot",text:"connected"});
-      });
+    node.serverConfig.on('connected', function () {
+      node.status({fill:"green",shape:"dot",text:"connected"});
+    });
 
-      maxCube.on('error', function (err) {
-        node.log(err);
-        node.status({fill:"red",shape:"dot",text:"Error: "+err});
-      });
-    }
+    node.serverConfig.on('error', function (err) {
+      node.log(err);
+      node.status({fill:"red",shape:"dot",text:"Error: "+err});
+    });
 
     return true;
   }
@@ -261,6 +258,7 @@ module.exports = function(RED) {
       if(node.maxCube){
         node.log("Preparing new Maxcube events callback");
         node.maxCube.on('closed', function () {
+          node.emit('closed');
           connected = false;
           if(node.maxCube != null) {
             node.log("Maxcube connection closed unexpectedly... will try to reconnect.");
@@ -270,6 +268,7 @@ module.exports = function(RED) {
             node.log("Maxcube connection closed...");
         });
         node.maxCube.on('error', function (e) {
+          node.emit('error', e);
           node.log("Error connecting to the cube.");
           node.log(JSON.stringify(e));
           connected = false;
@@ -278,8 +277,9 @@ module.exports = function(RED) {
           node.maxcubeConnect();
         });
         node.maxCube.on('connected', function () {
-            node.log("Maxcube connected");
-            connected = true;
+          node.emit('connected');
+          node.log("Maxcube connected");
+          connected = true;
         });
       }
     };

--- a/maxcube.js
+++ b/maxcube.js
@@ -238,15 +238,55 @@ module.exports = function(RED) {
     this.port = config.port;
     this.disabled = config.disabled;
 
-    if (this.disabled || !node.host || !node.port) {
-      return;
-    }
+    node.maxcubeConnect = function(){
 
-    node.maxCube = new MaxCube(node.host, node.port);
+      if(node.maxCube){
+         node.maxCube.close();
+         node.maxCube = undefined;
+      }
+
+      if (node.disabled || !node.host || !node.port) {
+        node.log("Maxcube disabled");
+        return;
+      }
+
+      //connect/new instance
+      node.log("Preparing new maxcube connection");
+      node.maxCube = new MaxCube(node.host, node.port);
+
+      //common events
+      if(node.maxCube){
+        node.log("Preparing new Maxcube events callback");
+        node.maxCube.on('closed', function () {
+          node.log("Maxcube connection closed...");
+          connected = false;
+        });
+        node.maxCube.on('error', function (e) {
+          node.log("Error connecting to the cube.");
+          node.log(JSON.stringify(e));
+          connected = false;
+          //force node to init connection if not available
+          node.log("Maxcube was disconnected... will try to reconnect.");
+          node.maxcubeConnect();
+        });
+        node.maxCube.on('connected', function () {
+            node.log("Maxcube connected");
+            connected = true;
+        });
+      }
+    };
 
     node.on("close", function() {
-      node.maxCube.close();
+      if(node.maxCube){
+        node.maxCube.close();
+      }
     });
+
+    //first connection
+    var connected = false;
+    node.maxcubeConnect();
+
   }
+
   RED.nodes.registerType("maxcube-server", MaxcubeServerNode);
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,27 @@
+{
+  "name": "node-red-contrib-maxcube2",
+  "version": "0.3.5",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "bluebird": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
+      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
+    },
+    "maxcube2": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/maxcube2/-/maxcube2-2.2.3.tgz",
+      "integrity": "sha512-6Qjd0GRtgRwonbunFuHyOtMaRZWyM7BHH0qhE9U4im4td3C60YDdM9W7B+Dn2BJbZPFoRNgC1e8trfk4fAQOIg==",
+      "requires": {
+        "bluebird": "^3.3.4",
+        "moment": "^2.17.1"
+      }
+    },
+    "moment": {
+      "version": "2.29.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
+      "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ=="
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-red-contrib-maxcube2",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "A node-red node to control the eQ-3 Max! Cube with maxcube2.js",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-red-contrib-maxcube2",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "A node-red node to control the eQ-3 Max! Cube with maxcube2.js",
   "repository": {
     "type": "git",
@@ -27,7 +27,8 @@
   "contributors": [
     "Ives De Bruycker",
     "Luca Mazzilli",
-    "tedstriker"
+    "tedstriker",
+    "Nils Schneider"
   ],
   "node-red": {
     "nodes": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-red-contrib-maxcube2",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "A node-red node to control the eQ-3 Max! Cube with maxcube2.js",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-red-contrib-maxcube2",
-  "version": "0.0.2",
+  "version": "0.1.0",
   "description": "A node-red node to control the eQ-3 Max! Cube with maxcube2.js",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-red-contrib-maxcube2",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "description": "A node-red node to control the eQ-3 Max! Cube with maxcube2.js",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-red-contrib-maxcube2",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "A node-red node to control the eQ-3 Max! Cube with maxcube2.js",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "url": "git://github.com/maxill1/node-red-contrib-maxcube2.git"
   },
   "dependencies": {
-    "maxcube2": "^2.1.2"
+    "maxcube2": "^2.2.2"
   },
   "keywords": [
     "node-red",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-red-contrib-maxcube2",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "A node-red node to control the eQ-3 Max! Cube with maxcube2.js",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-red-contrib-maxcube2",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "A node-red node to control the eQ-3 Max! Cube with maxcube2.js",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-red-contrib-maxcube2",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "A node-red node to control the eQ-3 Max! Cube with maxcube2.js",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-red-contrib-maxcube2",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "A node-red node to control the eQ-3 Max! Cube with maxcube2.js",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-red-contrib-maxcube2",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "A node-red node to control the eQ-3 Max! Cube with maxcube2.js",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-red-contrib-maxcube2",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "A node-red node to control the eQ-3 Max! Cube with maxcube2.js",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "node-red-contrib-maxcube2",
   "version": "0.0.1",
-  "description": "A node-red node to control the eQ-3 Max! Cube",
+  "description": "A node-red node to control the eQ-3 Max! Cube with maxcube2.js",
   "repository": {
     "type": "git",
     "url": "git://github.com/maxill1/node-red-contrib-maxcube2.git"

--- a/package.json
+++ b/package.json
@@ -1,24 +1,40 @@
 {
-  "name": "node-red-contrib-maxcube",
-  "version": "0.0.5",
+  "name": "node-red-contrib-maxcube2",
+  "version": "0.0.1",
   "description": "A node-red node to control the eQ-3 Max! Cube",
   "repository": {
     "type": "git",
-    "url": "git://github.com/ivesdebruycker/node-red-contrib-maxcube.git"
+    "url": "git://github.com/maxill1/node-red-contrib-maxcube2.git"
   },
   "dependencies": {
-    "maxcube": "^1.0.2"
+    "maxcube2": "^2.1.2"
   },
   "keywords": [
     "node-red",
-    "Max Cube"
+    "Max Cube",
+    "eq-3",
+    "eq3",
+    "maxcube",
+    "thermostat",
+    "home",
+    "heating",
+    "max",
+    "elv"
   ],
   "author": {
     "name": "Ives De Bruycker"
   },
+  "contributors": [
+    "Luca Mazzilli",
+    "tedstriker"
+  ],
   "node-red": {
     "nodes": {
       "maxcube": "maxcube.js"
     }
+  },
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/maxill1/node-red-contrib-maxcube2/issues"
   }
 }

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "Ives De Bruycker",
     "Luca Mazzilli",
     "tedstriker",
-    "Nils Schneider"
+    "Nils Schneider",
+    "Holger Pieta"
   ],
   "node-red": {
     "nodes": {


### PR DESCRIPTION
As admin with a broken network connection to my max cube,
I want to have a reconnection attempt at the earliest after one second
to not spill my log and slow down my device running node-red.

This has already been fixed for 'closed' listeners. We need to have a similar fix for 'error' listeners.